### PR TITLE
fix(ios): fixed build issue for iOS  device and simulator 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+ios
+iossimulator

--- a/Makefile
+++ b/Makefile
@@ -97,11 +97,11 @@ IOS_CFLAGS+=-I $(MCL_DIR)/include -I $(BLS_DIR)/include
 IOS_LDFLAGS=-dynamiclib -Wl,-flat_namespace -Wl,-undefined -Wl,suppress
 CURVE_BIT?=384_256
 IOS_LIB=libbls$(CURVE_BIT).a
-IOS_LIBS=ios/armv7/$(IOS_LIB) ios/arm64/$(IOS_LIB) iossimulator/x86_64/$(IOS_LIB) iossimulator/i386/$(IOS_LIB)
+IOS_LIBS=ios/armv7/$(IOS_LIB) ios/arm64/$(IOS_LIB)
 SIMULATOR_LIBS= iossimulator/arm64/$(IOS_LIB) iossimulator/x86_64/$(IOS_LIB) iossimulator/i386/$(IOS_LIB)
 
 
-ios: ios_simulator
+ios:
 	$(MAKE) each_ios OUTDIR="ios" MINVERSION="-mios-version-min" PLATFORM="iPhoneOS" ARCH=armv7 BIT=32 UNIT=4
 	$(MAKE) each_ios OUTDIR="ios" MINVERSION="-mios-version-min" PLATFORM="iPhoneOS" ARCH=arm64 BIT=64 UNIT=8
 	@echo $(IOS_LIBS)

--- a/bls/link.go
+++ b/bls/link.go
@@ -1,8 +1,10 @@
+//go:build !ios
+// +build !ios
+
 package bls
 
 /*
 #cgo LDFLAGS:-lbls384_256 -lstdc++ -lm
-#cgo ios LDFLAGS:-L${SRCDIR}/lib/ios
 #cgo android,arm64 LDFLAGS:-L${SRCDIR}/lib/linux/arm64
 #cgo android,arm LDFLAGS:-L${SRCDIR}/lib/android/armeabi-v7a
 #cgo android,amd64 LDFLAGS:-L${SRCDIR}/lib/linux/amd64

--- a/bls/link_ios.go
+++ b/bls/link_ios.go
@@ -1,0 +1,10 @@
+//go:build ios && !iossimulator
+// +build ios,!iossimulator
+
+package bls
+
+/*
+#cgo LDFLAGS:-lbls384_256 -lstdc++ -lm
+#cgo ios LDFLAGS:-L${SRCDIR}/lib/ios
+*/
+import "C"

--- a/bls/link_iossimulator.go
+++ b/bls/link_iossimulator.go
@@ -1,0 +1,10 @@
+//go:build iossimulator
+// +build iossimulator
+
+package bls
+
+/*
+#cgo LDFLAGS:-lbls384_256 -lstdc++ -lm
+#cgo ios LDFLAGS:-L${SRCDIR}/lib/iossimulator
+*/
+import "C"


### PR DESCRIPTION
## Fixes
- fixed `-mios-simulator-version-min` bug for iOS simulator building
- added `make ios_simulator` to build iOS simulator binary
- removed simulator library from iOS binary. Because lipo is impossible to combine two arm64 libraries for ios/arm64 and iosimulator/arm64.

see example on https://github.com/0chain/gosdk/pull/499