### PR TITLE
feat(devops): added release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,241 @@
+name: Release
+
+
+permissions:
+  contents: write
+  repository-projects: write
+
+concurrency:
+  group: "release-${{ github.ref }}"
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'release/tag: vX.Y.Z'
+        required: true
+env:
+  BRANCH_NAME: "release-${{ github.event.inputs.version }}"
+
+jobs:
+  create-branch:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Create branch 
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        run: |
+          git checkout -b "$BRANCH_NAME"
+          git submodule update --init --recursive
+
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git push --set-upstream origin "$BRANCH_NAME"
+
+  build-linux:
+    runs-on: ubuntu-latest
+    needs: create-branch
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ^1.20
+
+      - name: Install Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+
+      - uses: android-actions/setup-android@v2
+
+      - name: Install Android Platform
+        run: |
+          sdkmanager "platform-tools"
+          sdkmanager "platforms;android-29"
+          sdkmanager "build-tools;29.0.2"
+
+      - uses: nttld/setup-ndk@v1
+        id: setup-ndk
+        with:
+          ndk-version: r21d
+
+      - name: Checkout branch 
+        run: |
+          git pull && git checkout "$BRANCH_NAME" && git pull
+          git submodule update --init --recursive
+
+      - name: Build linux
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        run: |
+          sudo apt install nasm
+          make clean
+          make CXX=clang++
+
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+
+          git add ./bls/lib/linux/ -f
+          git commit -m "fix(release): added libs for linux"
+          git push
+
+      - name: Build android
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        run: |
+          make clean
+          make android
+
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+ 
+          git add ./bls/lib/android/ -f
+          git commit -m "fix(release): added libs for android"
+          git push
+
+  build-macos:
+    runs-on: macos-latest
+    needs: build-linux
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ^1.20
+
+      - name: Checkout branch 
+        run: |
+          git pull && git checkout "$BRANCH_NAME" && git pull
+          git submodule update --init --recursive
+
+      - name: Build darwin
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        run: |
+          brew install nasm
+          make clean
+          make
+
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+
+          git add ./bls/lib/darwin/ -f
+          git commit -m "fix(release): added libs for darwin"
+          git push
+
+      - name: Build ios
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        run: |
+          make clean
+
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+
+          make ios
+          git add ./bls/lib/ios -f
+
+          make ios_simulator
+          git add ./bls/lib/iossimulator -f
+
+          git commit -m "fix(release): added libs for ios/ios simulator"
+          git push
+
+  # build-windows:
+  #   runs-on: windows-latest
+  #   needs: create-branch
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v3
+
+  #     - name: Setup Go
+  #       uses: actions/setup-go@v3
+  #       with:
+  #         go-version: ^1.20
+
+  #     - name: Install LLVM
+  #       uses: crazy-max/ghaction-chocolatey@v2
+  #       with:
+  #         args: install llvm --version=15.0.7
+
+  #     - name: Install MSYS2
+  #       uses: crazy-max/ghaction-chocolatey@v2
+  #       with:
+  #         args: install msys2
+
+  #     - name: Checkout branch 
+  #       run: |
+  #         git pull && git checkout "$BRANCH_NAME" && git pull
+  #         git submodule update --init --recursive
+
+  #     - name: Build windows
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+  #       run: |
+  #         gcc --version
+  #         clang++ -v
+  #         make clean
+  #         make CXX=clang++ -j
+
+  #         git config user.name github-actions
+  #         git config user.email github-actions@github.com
+  #         git add ./bls/lib/windows -f
+  #         git commit -m "fix(release): added libs for windows"
+  #         git push
+
+  create-release:
+    runs-on: ubuntu-latest  
+    needs: build-macos
+    steps:     
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ^1.20
+
+      - name: Checkout branch 
+        run: |
+          git pull && git checkout "$BRANCH_NAME" && git pull
+          git submodule update --init --recursive
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: ${{ github.event.inputs.version }}
+          release_name: ${{ github.event.inputs.version }}
+          # body: |
+          #   Changes in this Release
+          #   - First Change
+          #   - Second Change
+          draft: false
+          prerelease: false
+
+  delete-branch:
+    runs-on: ubuntu-latest  
+    needs: [ create-release ]
+    if: always()
+    steps: 
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Delete branch
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git pull && git push origin -d "$BRANCH_NAME"
+


### PR DESCRIPTION
## Changes
- added a `release.yml` to create release with ios libs as mentioned on https://github.com/herumi/bls-go-binary/pull/9#issuecomment-1175922502.
- fixed #11  

## How it works
- create a branch `release-[github.events.inputs.version]`
- build libs for `linux`,`android`,`macos`,`ios` and `iossimulator`
- commit and push all libs on release branch only
- create release/tag from the release branch
- delete release branch

## Examples
- https://github.com/cnlangzi/bls-go-binary/actions/runs/4529468686
- https://github.com/cnlangzi/bls-go-binary/releases/tag/v0.0.1

## Notes
- please don't forget to assigned `read/write` permission to workflow job on `settings>action>general>workflow permission`
<img width="795" alt="Screenshot 2023-03-27 at 14 47 47" src="https://user-images.githubusercontent.com/347651/227862188-2a060a6f-2a45-450f-966f-0e496b551c0f.png">
