### PR TITLE
fix(devops): build linux/arm64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,19 @@ jobs:
         with:
           ndk-version: r21d
 
+      - name: Set up Docker Buildx
+        run: |
+          sudo apt update -y
+          sudo apt install wget
+          sudo apt install ca-certificates curl gnupg lsb-release -y
+          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+          sudo apt-get update -y
+          sudo apt-get install docker-ce docker-ce-cli containerd.io -y
+          export DOCKER_CLI_EXPERIMENTAL=enabled
+          docker run --privileged --rm tonistiigi/binfmt --install all
+          docker context create docker_buildx
+
       - name: Build linux
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
@@ -83,6 +96,7 @@ jobs:
           mkdir -p ./bls/lib/linux/
 
           make CXX=clang++
+          make build_linux_arm64
 
           git config user.name github-actions
           git config user.email github-actions@github.com

--- a/Makefile
+++ b/Makefile
@@ -31,4 +31,8 @@ clean:
 	$(MAKE) -C $(BLS_DIR) clean
 	$(RM) -rf obj/*.o android/obj/* bls/lib/android/*
 
-.PHONY: android ios each_ios clean
+build_linux_arm64:
+	docker buildx build --platform linux/arm64 --progress=plain -f ./dockerfile . -t bls-go-binary -o "type=local,dest=."
+
+.PHONY: android ios each_ios clean build_linux
+

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,32 @@
+FROM ubuntu:22.04 as bls-go-binary-build
+
+RUN apt update && apt -y install curl nasm build-essential llvm clang-14
+RUN if [ "$(uname -m)" = "x86_64" ] ; then curl -L -o go1.20.4.tar.gz https://go.dev/dl/go1.20.4.linux-amd64.tar.gz ; else curl -L -o go1.20.4.tar.gz https://go.dev/dl/go1.20.4.linux-arm64.tar.gz ; fi
+RUN tar -C /usr/local -xzf go1.20.4.tar.gz
+RUN export PATH=$PATH:/usr/local/go/bin
+ENV PATH=$PATH:/usr/local/go/bin
+RUN go version
+
+RUN update-alternatives --verbose \
+      --install /usr/bin/clang                 clang                 /usr/bin/clang-14 100 \
+      --slave   /usr/bin/clang++               clang++               /usr/bin/clang++-14  \
+      --slave   /usr/bin/clang-cpp             clang-cpp             /usr/bin/clang-cpp-14
+
+WORKDIR /usr/local/bls-go-binary
+
+# Download the dependencies:
+# Will be cached if we don't change mod/sum files
+COPY ./go.mod ./go.sum ./
+RUN go mod download
+
+COPY .  .
+
+
+RUN make clean
+RUN mkdir -p ./bls/lib/linux/
+
+RUN make CXX=clang++ ARCH=x86_64
+RUN make CXX=clang++ ARCH=amd64
+
+FROM scratch AS bls-go-binary-export
+COPY --from=bls-go-binary-build /usr/local/bls-go-binary/bls/lib/linux/ /bls/lib/linux/

--- a/dockerfile
+++ b/dockerfile
@@ -25,8 +25,7 @@ COPY .  .
 RUN make clean
 RUN mkdir -p ./bls/lib/linux/
 
-RUN make CXX=clang++ ARCH=x86_64
-RUN make CXX=clang++ ARCH=amd64
+RUN make CXX=clang++
 
 FROM scratch AS bls-go-binary-export
 COPY --from=bls-go-binary-build /usr/local/bls-go-binary/bls/lib/linux/ /bls/lib/linux/


### PR DESCRIPTION
## Fixes
- fixed https://github.com/herumi/bls-go-binary/issues/24 : build linux/arm64 on release.yml